### PR TITLE
Update LOTF2.asl

### DIFF
--- a/LOTF2.asl
+++ b/LOTF2.asl
@@ -13,21 +13,21 @@ state("LOTF2-Win64-Shipping", "v.1.1.249 Steam")
 {
 	long movementBase	: 0x08827FE0, 0x30, 0x2F0, 0x340; // LocalPlayer -> Controller -> Character -> MovementBase;
 	byte loadingState	: 0x08827FE0, 0x30, 0x2F0, 0x2C0, 0x582; // LocalPlayer -> Controller -> Character -> PlayerState -> LoadingState;
-	ulong levelFGUID	: 0x08840A38, 0x30, 0x210; // GWorld -> PersistentLevel -> LevelBuildDataId;
+	ulong levelFGUID	: 0x08827FE0, 0x30, 0x20, 0x210; // GWorld -> PersistentLevel -> LevelBuildDataId;
 }
 
 state("LOTF2-Win64-Shipping", "v.1.1.224 Steam")
 {
 	long movementBase	: 0x08821BE0, 0x30, 0x2F0, 0x340; // LocalPlayer -> Controller -> Character -> MovementBase;
 	byte loadingState	: 0x08821BE0, 0x30, 0x2F0, 0x2C0, 0x582; // LocalPlayer -> Controller -> Character -> PlayerState -> LoadingState;
-	ulong levelFGUID	: 0x08840A38, 0x30, 0x210; // GWorld -> PersistentLevel -> LevelBuildDataId;
+	ulong levelFGUID	: 0x08821BE0, 0x30, 0x20, 0x210; // GWorld -> PersistentLevel -> LevelBuildDataId;
 }
 
 state("LOTF2-Win64-Shipping", "v.1.1.216 Steam")
 {
 	long movementBase	: 0x0881DB60, 0x30, 0x2F0, 0x340; // LocalPlayer -> Controller -> Character -> MovementBase;
 	byte loadingState	: 0x0881DB60, 0x30, 0x2F0, 0x2C0, 0x582; // LocalPlayer -> Controller -> Character -> PlayerState -> LoadingState;
-	ulong levelFGUID	: 0x08840A38, 0x30, 0x210; // GWorld -> PersistentLevel -> LevelBuildDataId;
+	ulong levelFGUID	: 0x0881DB60, 0x30, 0x20, 0x210; // GWorld -> PersistentLevel -> LevelBuildDataId;
 }
 
 init

--- a/LOTF2.asl
+++ b/LOTF2.asl
@@ -2,10 +2,19 @@
 Lords of the Fallen Load 2 Remover
 Made by CactusDuper and Hazeblade
 
-Last updated: 23 Oct 2023
+Last updated: 1 Nov 2023
 
-Currently steam only
+Currently Steam Only
 */
+
+//224 and 216 need updates to their levelFGUID addresses.
+
+state("LOTF2-Win64-Shipping", "v.1.1.249 Steam")
+{
+	long movementBase	: 0x08827FE0, 0x30, 0x2F0, 0x340; // LocalPlayer -> Controller -> Character -> MovementBase;
+	byte loadingState	: 0x08827FE0, 0x30, 0x2F0, 0x2C0, 0x582; // LocalPlayer -> Controller -> Character -> PlayerState -> LoadingState;
+	ulong levelFGUID	: 0x08840A38, 0x30, 0x210; // GWorld -> PersistentLevel -> LevelBuildDataId;
+}
 
 state("LOTF2-Win64-Shipping", "v.1.1.224 Steam")
 {
@@ -14,10 +23,33 @@ state("LOTF2-Win64-Shipping", "v.1.1.224 Steam")
 	ulong levelFGUID	: 0x08840A38, 0x30, 0x210; // GWorld -> PersistentLevel -> LevelBuildDataId;
 }
 
+state("LOTF2-Win64-Shipping", "v.1.1.216 Steam")
+{
+	long movementBase	: 0x0881DB60, 0x30, 0x2F0, 0x340; // LocalPlayer -> Controller -> Character -> MovementBase;
+	byte loadingState	: 0x0881DB60, 0x30, 0x2F0, 0x2C0, 0x582; // LocalPlayer -> Controller -> Character -> PlayerState -> LoadingState;
+	ulong levelFGUID	: 0x08840A38, 0x30, 0x210; // GWorld -> PersistentLevel -> LevelBuildDataId;
+}
+
 init
 {
-	vars.firstCutsceneFinished = false;
 	vars.hasStarted = false;
+	
+	// Turn on to get memory size for latest patch. Will be used to identify version number. Don't forget to change the directory!
+	// System.IO.File.WriteAllText(@"C:\Your\Directory\Here\modulesize.txt", "ModuleMemorySize: " + modules.First().ModuleMemorySize.ToString());
+	
+	switch (modules.First().ModuleMemorySize)
+	{
+		case (151691264):
+			version = "v.1.1.249 Steam";
+			break;
+		case (151662592):
+			version = "v.1.1.224 Steam";
+			break;
+		case (151646208):
+		default:
+			version = "v.1.1.216 Steam";
+			break;
+	}
 }
 
 onStart


### PR DESCRIPTION
Append states for v249 and v216 and expand the script to recognize which patch is installed based on memory size. NOTE: 216 and 249 still need updated levelFGUID addresses to work properly.